### PR TITLE
사진 추가 권한 내용 추가가 필요합니다

### DIFF
--- a/HowlPrivacy/Info.plist
+++ b/HowlPrivacy/Info.plist
@@ -28,6 +28,8 @@
 	<string>카메라를 찍기 위해서 권한이 필요합니다.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>앨범을 가져오기 위해서는 권한이 필요합니다.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>앨범에 사진을 저장하기 위해서는 권한이 필요합니다.</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
안녕하세요, 하울선생님 
유튜브에서 카메라 관련 영상을 찾아보다가 우연히 보게되었는데
짧고 굵고 차분하게 잘 설명해주셔서 영상 감사히 보며 학습하고 있습니다 ^^

테스트하다가 카메라 저장기능이 
제 폰(device 6s plus / ios 11.4.1) 에서 실행이 안되어서 오류코드를 보니까
앨범에 사진을 추가 할 때에도 권한이 필요하다고 나오더라구요

이런 내용을 추가 하니 실행이 잘되네요!
* xcode에서 키 이름은 Privacy - Photo Library Additions Usage Description 입니다!

감사합니다 ^^!!